### PR TITLE
Add DataTables bower dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,6 +30,7 @@
     "angular-animate": "1.5.6",
     "angular-sanitize": "1.5.6",
     "angular-bootstrap": "1.3.3",
+    "datatables.net": "1.10.12",
     "datatables.net-responsive": "2.1.0",
     "datatables.net-responsive-dt": "2.1.0",
     "angular-datatables": "0.5.5",


### PR DESCRIPTION
## Summary

Adds the missing `datatables.net` Bower dependency so the Docker build installs the DataTables core JavaScript file that the staff frontend loads from `/static/bower_components/datatables.net/js/jquery.dataTables.min.js`.

## Root Cause

The staff page includes DataTables core before `dataTables.responsive.min.js`, but `bower.json` only declared the responsive and Angular wrapper packages. In the deployed container, the responsive package was present while the core `datatables.net` asset returned 404, causing `c.fn.dataTable is undefined` when the responsive plugin executed.

## Validation

- Confirmed the live core asset returns 404 while the responsive asset returns 200.
- Confirmed `datatables.net` version `1.10.12` exposes the exact `js/jquery.dataTables.min.js` path referenced by the template.
- Validated `bower.json` parses as JSON.

Docker/npm were not available in the Codex environment, so the container rebuild still needs to be run in an environment with Docker.